### PR TITLE
Add configurable PostgreSQL support and migration plan

### DIFF
--- a/Data/SiteContextConfiguration.cs
+++ b/Data/SiteContextConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Modisette.Data;
+
+public static class SiteContextConfiguration
+{
+    public const string SqliteProvider = "sqlite";
+    public const string PostgresProvider = "postgres";
+
+    public static void Configure(DbContextOptionsBuilder options, IConfiguration configuration)
+    {
+        var provider = NormalizeProvider(configuration[$"{Models.DatabaseOptions.SectionName}:Provider"]);
+
+        if (provider == PostgresProvider)
+        {
+            var connectionString = configuration.GetConnectionString("Postgres")
+                ?? throw new InvalidOperationException("Connection string 'Postgres' not found.");
+
+            options.UseNpgsql(connectionString);
+            return;
+        }
+
+        if (provider == SqliteProvider)
+        {
+            var connectionString = configuration.GetConnectionString("SiteContext")
+                ?? throw new InvalidOperationException("Connection string 'SiteContext' not found.");
+
+            options.UseSqlite(connectionString);
+            return;
+        }
+
+        throw new InvalidOperationException("Database:Provider must be either 'sqlite' or 'postgres'.");
+    }
+
+    public static string NormalizeProvider(string? provider)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return SqliteProvider;
+        }
+
+        return provider.Trim().ToLowerInvariant() switch
+        {
+            "postgresql" => PostgresProvider,
+            var value => value
+        };
+    }
+}

--- a/Data/SiteContextFactory.cs
+++ b/Data/SiteContextFactory.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace Modisette.Data;
+
+public sealed class SiteContextFactory : IDesignTimeDbContextFactory<SiteContext>
+{
+    public SiteContext CreateDbContext(string[] args)
+    {
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile($"appsettings.{environment}.json", optional: true)
+            .AddUserSecrets<SiteContextFactory>(optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<SiteContext>();
+        SiteContextConfiguration.Configure(optionsBuilder, configuration);
+        return new SiteContext(optionsBuilder.Options);
+    }
+}

--- a/Models/DatabaseOptions.cs
+++ b/Models/DatabaseOptions.cs
@@ -1,0 +1,7 @@
+namespace Modisette.Models;
+
+public sealed class DatabaseOptions
+{
+    public const string SectionName = "Database";
+    public string Provider { get; set; } = "sqlite";
+}

--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddOptions<AdminAuthOptions>()
                 .Bind(builder.Configuration.GetSection(AdminAuthOptions.SectionName))
                 .ValidateOnStart();
+builder.Services.AddOptions<DatabaseOptions>()
+                .Bind(builder.Configuration.GetSection(DatabaseOptions.SectionName))
+                .ValidateOnStart();
 builder.Services.AddOptions<EmailServerConfiguration>()
                 .Bind(builder.Configuration.GetSection("EmailConfiguration"))
                 .ValidateDataAnnotations()
@@ -24,6 +27,7 @@ builder.Services.AddOptions<EmailAddress>()
                 .ValidateOnStart();
 
 builder.Services.AddSingleton<Microsoft.Extensions.Options.IValidateOptions<AdminAuthOptions>, AdminAuthOptionsValidator>();
+builder.Services.AddSingleton<Microsoft.Extensions.Options.IValidateOptions<DatabaseOptions>, DatabaseOptionsValidator>();
 
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .AddCookie(options =>
@@ -59,9 +63,8 @@ builder.Services.AddRazorPages(options =>
                        .AllowAnonymousToPage("/Admin/Account/Login");
 });
 
-builder.Services.AddDbContext<SiteContext>(options =>
-    options.UseSqlite(builder.Configuration.GetConnectionString("SiteContext") 
-    ?? throw new InvalidOperationException("Connection string 'SiteContext' not found.")));
+builder.Services.AddDbContext<SiteContext>((sp, options) =>
+    SiteContextConfiguration.Configure(options, sp.GetRequiredService<IConfiguration>()));
 
 builder.Services.AddScoped<IContactService, ContactService>();
 builder.Services.AddScoped<ICourseService, CourseService>();

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This capstone project for CODE: You is a personal website for a client that feat
 
 This project demonstrates my ability to develop viable solutions for clients by creating cohesive full-stack applications with secure authentication and authorization flows.
 
+The app now supports SQLite for local development and PostgreSQL for deployment. Provider selection is configuration-driven, so the same code path can run locally on SQLite and in production on Supabase Postgres.
+
 ## Table of Contents
 
 - [Demo](#demo)
@@ -45,6 +47,7 @@ This project demonstrates my ability to develop viable solutions for clients by 
 - Entity Framework Core
 - ASP.NET Core Cookie Authentication
 - Google SMTP
+- PostgreSQL / Supabase-ready provider support
 - SQLite
 
 ## Setup Instructions
@@ -66,6 +69,7 @@ This project demonstrates my ability to develop viable solutions for clients by 
     dotnet user-secrets init
     dotnet user-secrets set "AdminAuth:Username" "admin"
     dotnet user-secrets set "AdminAuth:Password" "change-this-before-sharing"
+    dotnet user-secrets set "Database:Provider" "sqlite"
     dotnet user-secrets set "EmailConfiguration:From" "your-smtp-address@example.com"
     dotnet user-secrets set "EmailConfiguration:SmtpServer" "smtp.gmail.com"
     dotnet user-secrets set "EmailConfiguration:SmtpPort" "465"
@@ -87,6 +91,24 @@ This project demonstrates my ability to develop viable solutions for clients by 
 ### Admin Password Hash Option
 
 For production, prefer a hashed admin password instead of storing plaintext in configuration. The app accepts a PBKDF2 value in the format `PBKDF2$iterations$salt$hash` via `AdminAuth:PasswordHash`. If `PasswordHash` is supplied, it is used instead of `AdminAuth:Password`.
+
+### PostgreSQL Configuration
+
+For Render or any other deployed environment, set these values:
+
+```sh
+Database__Provider=postgres
+ConnectionStrings__Postgres=Host=...;Port=5432;Database=...;Username=...;Password=...;SSL Mode=Require;Trust Server Certificate=true
+```
+
+Local development can continue using SQLite with:
+
+```sh
+Database__Provider=sqlite
+ConnectionStrings__SiteContext=Data Source=Modisette.db
+```
+
+The current checked-in EF migrations were created against SQLite. The cutover plan for creating a PostgreSQL baseline and moving data is documented in [docs/postgres-migration.md](docs/postgres-migration.md).
 
 ## Quality Checks
 

--- a/Services/DatabaseOptionsValidator.cs
+++ b/Services/DatabaseOptionsValidator.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Modisette.Data;
+using Modisette.Models;
+
+namespace Modisette.Services;
+
+public sealed class DatabaseOptionsValidator : IValidateOptions<DatabaseOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public DatabaseOptionsValidator(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public ValidateOptionsResult Validate(string? name, DatabaseOptions options)
+    {
+        var provider = SiteContextConfiguration.NormalizeProvider(options.Provider);
+
+        if (provider is not (SiteContextConfiguration.SqliteProvider or SiteContextConfiguration.PostgresProvider))
+        {
+            return ValidateOptionsResult.Fail("Database:Provider must be either 'sqlite' or 'postgres'.");
+        }
+
+        var connectionStringName = provider == SiteContextConfiguration.PostgresProvider ? "Postgres" : "SiteContext";
+        if (string.IsNullOrWhiteSpace(_configuration.GetConnectionString(connectionStringName)))
+        {
+            return ValidateOptionsResult.Fail($"ConnectionStrings:{connectionStringName} is required when Database:Provider is '{provider}'.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,8 +6,12 @@
     }
   },
   "AllowedHosts": "*",
+  "Database": {
+    "Provider": "sqlite"
+  },
   "ConnectionStrings": {
-    "SiteContext": "Data Source=Modisette.db"
+    "SiteContext": "Data Source=Modisette.db",
+    "Postgres": ""
   },
   "AdminAuth": {
     "Username": "",

--- a/docs/postgres-migration.md
+++ b/docs/postgres-migration.md
@@ -1,0 +1,53 @@
+# PostgreSQL Migration Plan
+
+## Goal
+
+Move production persistence from the local SQLite file to Supabase Postgres without breaking local development. The application code now supports both providers through configuration:
+
+- `Database:Provider=sqlite` uses `ConnectionStrings:SiteContext`
+- `Database:Provider=postgres` uses `ConnectionStrings:Postgres`
+
+## Current State
+
+- Local development defaults to SQLite.
+- Existing EF Core migrations under `Migrations/` were generated against SQLite.
+- Production target is Supabase Postgres.
+- Uploaded files still live under `wwwroot/Uploads`, so storage cutover remains a separate task.
+
+## Recommended Cutover Strategy
+
+1. Provision the Supabase Postgres database and collect the SSL-required connection string.
+2. Switch a local development environment to Postgres with `Database__Provider=postgres` and `ConnectionStrings__Postgres=...`.
+3. Create a PostgreSQL baseline migration after deciding whether to keep the existing migration history or replace it with a fresh provider-neutral baseline.
+4. Apply the Postgres migration to an empty Supabase database.
+5. Export the current SQLite data and import it into Postgres.
+6. Validate the app locally against Postgres before any deployment cutover.
+7. Update the Render production environment to use the Postgres provider and connection string.
+8. Deploy and verify CRUD, contact submissions, and admin login on the hosted site.
+
+## Important Constraint
+
+The current migrations include SQLite-specific annotations such as `Sqlite:Autoincrement`. That means the safest cutover is usually one of these approaches:
+
+1. Create a fresh Postgres baseline migration once the model is stable.
+2. Or maintain provider-specific migrations if you need both providers to evolve independently.
+
+For this project, a fresh Postgres baseline is the lower-complexity path.
+
+## Proposed Implementation Order
+
+1. Keep SQLite as the default local provider.
+2. Add Postgres provider support in application startup and design-time EF tooling.
+3. Create the first Postgres baseline migration.
+4. Add a small one-time data migration path from SQLite to Postgres.
+5. Cut production over to Supabase.
+6. Later, remove SQLite entirely if local file-based development is no longer useful.
+
+## Validation Checklist
+
+1. `dotnet build --configuration Release modisette.sln`
+2. `dotnet test --configuration Release modisette.sln`
+3. `dotnet ef dbcontext info` with SQLite settings
+4. `dotnet ef dbcontext info` with Postgres settings
+5. `dotnet ef database update` against a disposable Postgres database
+6. Manual verification of contact form persistence, admin CRUD, and content reads

--- a/modisette.csproj
+++ b/modisette.csproj
@@ -23,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SQLite" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This pull request adds support for using either SQLite or PostgreSQL as the database provider, configurable via application settings. The changes enable seamless switching between local development (SQLite) and production (PostgreSQL/Supabase), update configuration and validation, and provide documentation for migration and setup.

**Database provider support and configuration:**

* Introduced `SiteContextConfiguration` and `SiteContextFactory` to centralize and abstract `DbContext` provider selection, allowing the app to use SQLite or PostgreSQL based on configuration. (`Data/SiteContextConfiguration.cs`, `Data/SiteContextFactory.cs`) [[1]](diffhunk://#diff-b354b01b34f6dd726c846e368672fcb83a521c684050cce642260df8f8e4f41cR1-R48) [[2]](diffhunk://#diff-e7345cca9f9c1ea2db29e48559c43fd3241e376ece84d8f410a396b087e73044R1-R24)
* Added `DatabaseOptions` model and `DatabaseOptionsValidator` to ensure correct provider and connection string configuration at startup. (`Models/DatabaseOptions.cs`, `Services/DatabaseOptionsValidator.cs`) [[1]](diffhunk://#diff-2d81dfd7ece4b945b6a89e92c99fddf74165f9b971a5436e58dc33772dc8b5edR1-R7) [[2]](diffhunk://#diff-cf954de9d7536b2d5bf940821ff71abbdb4816f59fb6146541f078981177137fR1-R34)
* Updated `Program.cs` to register `DatabaseOptions`, its validator, and to use the new provider-agnostic configuration for `SiteContext`. [[1]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bR17-R19) [[2]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bR30) [[3]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bL62-R67)
* Updated `appsettings.json` to include a `Database` section and a placeholder for the Postgres connection string.
* Added the Npgsql EF Core provider to project dependencies. (`modisette.csproj`)

**Documentation and developer guidance:**

* Expanded `README.md` with provider selection instructions, environment variable examples, and a section on PostgreSQL configuration for deployment. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R95-R112)
* Added a detailed migration plan for moving from SQLite to PostgreSQL in `docs/postgres-migration.md`.