### PR TITLE
Fix contact form duplicate submits and harden SMTP delivery

### DIFF
--- a/Models/EmailServerConfiguration.cs
+++ b/Models/EmailServerConfiguration.cs
@@ -8,6 +8,8 @@ public class EmailServerConfiguration
     [EmailAddress]
     public string From { get; set; } = string.Empty;
 
+    public string SecureSocketOptions { get; set; } = "Auto";
+
     [Range(1, 65535)]
     public int SmtpPort { get; set; } = 465;
 

--- a/Pages/Contact.cshtml
+++ b/Pages/Contact.cshtml
@@ -65,4 +65,29 @@
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");
     }
+
+    <script>
+        (() => {
+            const form = document.getElementById("contactForm");
+            const submitButton = document.getElementById("submitButton");
+
+            if (!form || !submitButton) {
+                return;
+            }
+
+            form.addEventListener("submit", event => {
+                if (submitButton.disabled) {
+                    event.preventDefault();
+                    return;
+                }
+
+                if (window.jQuery && !window.jQuery(form).valid()) {
+                    return;
+                }
+
+                submitButton.disabled = true;
+                submitButton.textContent = "Submitting...";
+            });
+        })();
+    </script>
 }

--- a/Pages/Contact.cshtml.cs
+++ b/Pages/Contact.cshtml.cs
@@ -7,6 +7,8 @@ namespace Modisette.Pages;
 
 public class ContactModel : PageModel
 {
+    private static readonly TimeSpan EmailSendTimeout = TimeSpan.FromSeconds(10);
+
     // Dependency Inversion Principle (DIP): Depend on abstractions (interfaces) rather than concrete implementations.
     private readonly IContactService _contactService;
     private readonly IEmailService _emailService;
@@ -36,6 +38,8 @@ public class ContactModel : PageModel
             return Page();
         }
 
+        await _contactService.CreateContactAsync(Contact);
+
         // Single Responsibility Principle (SRP): Delegates the message building responsibility to the IContactMessageBuilder service.
         // Creates an email message from the contact form data.
         EmailMessage messageToSend = _contactMessageBuilder.BuildMessage(Contact);
@@ -43,15 +47,16 @@ public class ContactModel : PageModel
         try
         {
             // Single Responsibility Principle (SRP): Delegates the email sending responsibility to the IEmailService service.
-            await _emailService.Send(messageToSend);
+            await _emailService.Send(messageToSend).WaitAsync(EmailSendTimeout);
+        }
+        catch (TimeoutException ex)
+        {
+            _logger.LogWarning(ex, "Timed out sending contact form notification email after {TimeoutSeconds} seconds.", EmailSendTimeout.TotalSeconds);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to send contact form notification email.");
         }
-
-        // Adds the contact form data to the database.
-        await _contactService.CreateContactAsync(Contact);
 
         return RedirectToPage("./Index");
     }

--- a/README.md
+++ b/README.md
@@ -72,13 +72,16 @@ The app now supports SQLite for local development and PostgreSQL for deployment.
     dotnet user-secrets set "Database:Provider" "sqlite"
     dotnet user-secrets set "EmailConfiguration:From" "your-smtp-address@example.com"
     dotnet user-secrets set "EmailConfiguration:SmtpServer" "smtp.gmail.com"
-    dotnet user-secrets set "EmailConfiguration:SmtpPort" "465"
+    dotnet user-secrets set "EmailConfiguration:SmtpPort" "587"
+    dotnet user-secrets set "EmailConfiguration:SecureSocketOptions" "StartTls"
     dotnet user-secrets set "EmailConfiguration:SmtpUsername" "your-smtp-address@example.com"
     dotnet user-secrets set "EmailConfiguration:SmtpPassword" "your-app-password"
     dotnet user-secrets set "SiteEmailAddress:Name" "Site Owner"
     dotnet user-secrets set "SiteEmailAddress:Address" "owner@example.com"
     ```
     The app now validates these settings at startup. If they are missing or malformed, startup will fail instead of falling back to checked-in placeholders.
+
+    For cloud deployments, prefer port `587` with `EmailConfiguration:SecureSocketOptions=StartTls`. Port `465` with implicit TLS can time out in some hosted environments.
 5. Set up the database:
     ```sh
     dotnet ef database update

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -9,30 +9,40 @@ namespace Modisette.Services;
 public class MailKitEmailService: IEmailService
 {
     private readonly EmailServerConfiguration _eConfig;
+
     public MailKitEmailService(EmailServerConfiguration config)
     {
         _eConfig = config;
     }
 
-    public async Task Send(EmailMessage emailMessage)
+    public async Task Send(EmailMessage message)
     {
-        var message = new MimeMessage();
-        message.From.AddRange(emailMessage.FromEmailAddress.Select(x => new MailboxAddress(x.Name, x.Address)));
-        message.To.AddRange(emailMessage.ToEmailAddress.Select(x => new MailboxAddress(x.Name, x.Address)));
-        message.Subject = emailMessage.Subject;
-        message.Body = new TextPart("plain")
+        var mimeMessage = new MimeMessage();
+        mimeMessage.From.AddRange(message.FromEmailAddress.Select(x => new MailboxAddress(x.Name, x.Address)));
+        mimeMessage.To.AddRange(message.ToEmailAddress.Select(x => new MailboxAddress(x.Name, x.Address)));
+        mimeMessage.Subject = message.Subject;
+        mimeMessage.Body = new TextPart("plain")
         {
-            Text = emailMessage.Content
+            Text = message.Content
         };
 
         using (var client = new MailKit.Net.Smtp.SmtpClient())
         {
-            await client.ConnectAsync(_eConfig.SmtpServer, _eConfig.SmtpPort, true);
+            client.Timeout = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
+
+            await client.ConnectAsync(_eConfig.SmtpServer, _eConfig.SmtpPort, GetSecureSocketOptions());
 
             await client.AuthenticateAsync(_eConfig.SmtpUsername, _eConfig.SmtpPassword);
 
-            await client.SendAsync(message);
+            await client.SendAsync(mimeMessage);
             await client.DisconnectAsync(true);
         }
+    }
+
+    private SecureSocketOptions GetSecureSocketOptions()
+    {
+        return Enum.TryParse<SecureSocketOptions>(_eConfig.SecureSocketOptions, ignoreCase: true, out var secureSocketOptions)
+            ? secureSocketOptions
+            : SecureSocketOptions.Auto;
     }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -20,6 +20,7 @@
   },
   "EmailConfiguration": {
     "From": "",
+    "SecureSocketOptions": "Auto",
     "SmtpPort": 465,
     "SmtpServer": "",
     "SmtpUsername": "",


### PR DESCRIPTION
This pull request improves the email sending functionality by making the SMTP connection options more configurable and robust, updating the default configuration for better compatibility, and enhancing the user experience and reliability of the contact form submission process. The most important changes are grouped below.

**Email configuration and sending improvements:**

* Added a `SecureSocketOptions` property to `EmailServerConfiguration`, allowing the SMTP security mode (e.g., `Auto`, `StartTls`) to be set via configuration. This is now used in `MailKitEmailService` to select the appropriate connection security when sending emails. [[1]](diffhunk://#diff-3a7626809b13b22c3b7a44dedd2163bec07563e017bd18e5f73b09e0db07f25fR11-R12) [[2]](diffhunk://#diff-d3ceffcff98e755128623fcbf6c4e23787f1a198ca383ccc0aabbb3c94ac4036R23) [[3]](diffhunk://#diff-9966537b89534604b76a787c90c5f2a271b183310cbc6b5f2037a8e0e26113d5R12-R47)
* Updated the default SMTP port to `587` and `SecureSocketOptions` to `StartTls` in the setup instructions, recommending these values for cloud deployments to avoid timeouts.
* Updated the email sending logic to use a 10-second timeout and improved exception handling for timeouts, logging a warning if sending takes too long. [[1]](diffhunk://#diff-9c8ec3dbcf8942b5f352837a60d079ec003788c0075e9dfa9c72bc6d95ea7319R10-R11) [[2]](diffhunk://#diff-9c8ec3dbcf8942b5f352837a60d079ec003788c0075e9dfa9c72bc6d95ea7319R41-L55)

**Contact form reliability and user experience:**

* Added JavaScript to the contact form to disable the submit button and display a "Submitting..." message during form submission, preventing duplicate submissions.

**Code and process improvements:**

* Moved the call to `_contactService.CreateContactAsync(Contact)` before sending the email, ensuring the contact is saved even if email sending fails or times out.